### PR TITLE
Add agenda for meeting on 11 May 2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore PDFs
+*.pdf
+# Ignore editor backup files
+*~

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,0 +1,1 @@
+A directory for agendas and minutes of meetings.

--- a/meetings/agendas/agenda-11-may-2020.md
+++ b/meetings/agendas/agenda-11-may-2020.md
@@ -1,0 +1,59 @@
+# OpenHW Software Task Group Meeting Agenda
+
+**Date:** Monday 8 May 2020
+
+**Time:**
+
+- 07:00-08:00 Pacific Time
+- 10:00-11:00 East Coast Time
+- 15:00-16:00 UK Time
+- 16:00-17:00 Central European Time
+- 22:00-23:00 Beijing Time
+
+**Location:** Zoom meeting
+
+- [us02web.zoom.us/j/85194416761](https://us02web.zoom.us/j/85194416761)
+- Meeting ID: 851 9441 6761
+- Find your local number: [us02web.zoom.us/u/kcVlqVA9vi](https://us02web.zoom.us/u/kcVlqVA9vi)
+
+**Chair:** Jeremy Bennett
+
+**Vice-Chair:** Yunhai Syh
+
+# Agenda
+
+1. Introduction
+
+2. Charter
+
+Our first objective is to agree our charter. An outline will be presented for discussion at the meeting. We should agree
+- what we are responsible for
+- what our goals are
+- how we will achieve those goals
+- how we will measure progress and success
+
+3. Migration of software repositories
+
+Notwithstanding our charter, OpenHW Group has agreed to take responsibility for the PULP software repositories. The existing repositories are three years out of date with respect to the upstream projects. The following suggested approach is for discussion. It addresses the subject of the GCC tool chain, but the approach should be capable of being generalized to other software.
+- all tool components should be moved upstream.
+  - for GCC, this is binutils-gdb, gcc, newlib and glibc
+- OpenHW should maintain only a repository with scripts to allow users to build an OpenHW version of the tool chain from source.
+
+Volunteers with expertise in upstream binutiles, GDB, GCC, newlib and gLibC are sought.
+
+4. Dates for future meetings
+
+It is proposed that the group meet monthly at 07:00 Pacific Time on the second Monday of the month. Discussion between times will be via Mattermost and mailing list (the latter to be set up). The monthly meetings will focus on taking decisions to progress the work of the charter. Where needed, additional meetings can be organized ad hoc. The dates for the next 6 meetings will be.
+
+- 11 May 2020 (this meeting)
+-  8 Jun 2020
+- 13 Jul 2020
+- 10 Aug 2020
+- 14 Sep 2020
+- 12 Oct 2020
+
+5. AOB
+
+
+Jeremy Bennett
+Chair

--- a/meetings/agendas/agenda-11-may-2020.md
+++ b/meetings/agendas/agenda-11-may-2020.md
@@ -1,6 +1,6 @@
 # OpenHW Software Task Group Meeting Agenda
 
-**Date:** Monday 8 May 2020
+**Date:** Monday 11 May 2020
 
 **Time:**
 
@@ -56,4 +56,3 @@ It is proposed that the group meet monthly at 07:00 Pacific Time on the second M
 
 
 Jeremy Bennett
-Chair


### PR DESCRIPTION
	This has necessitated adding some infrastructure.

Files changed:

	* .gitignore: Created to ignore editor backup and PDF files.
	* meetings/README.md: Created to explain purpose of the meeting
	directory.
	* meetings/agendas/agenda-11-may-2020.md: Created.