### PR TITLE
PicoPET:  toolchain helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.pdf
 # Ignore editor backup files
 *~
+# Ignore the subdirectories in toolchain/src and toolchain/build
+toolchain/src
+toolchain/build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -5,11 +5,12 @@
 This directory contains basic scripts for building local instances of CORE-V toolchains.
 The scripts provide the means of fetching the source code and building the executables
 and libraries for well-defined toolchain configurations.  The intention is to
-simplify the processs of building such toolchains and make is as "push-button"
+simplify the processs of building such toolchains and make it as "push-button"
 (and as accessible to CORE-V users) as reasonably possible.
 
 Currently, the scripts support only 'bare metal' toolchain configurations
-intended for hardware verification.  These configurations consist of:
+intended for hardware verification of 32- and 64-bit RISC-V targets.
+These configurations are deliberately lightweight and consist of:
 
 * `binutils`: assembler, linker, and object file utilities
 * `GCC`: the GNU GCC compiler configured for C only
@@ -17,7 +18,7 @@ intended for hardware verification.  These configurations consist of:
 
 Several extensions are envisioned:
 
-* Explicit selection of GDB versions
+* Explicit selection of GDB version
 * Addition of LLVM/Clang compilers
 * Support for Linux-based target environments
 * Addition of full-featured C library implementations
@@ -27,15 +28,13 @@ Several extensions are envisioned:
 Once the prerequisites (see [below](#Prerequisites)) are satisfied, you can fetch and build the
 latest supported upstream GCC toolchain for bare-metal 32-bit and 64-bit applications in just three steps:
 
-    # 1. Select an installation location for the toolchain (e.g., the path in
-      $RISCV).
+    # 1. Select an installation location for the toolchain (e.g., the 'toolchain' subdirectory of $RISCV).
     INSTALL_DIR=$RISCV/toolchain
     
     # 2. Fetch the source code of the toolchain (assumes Internet access.)
     sh get-toolchain.sh
     
-    # 3. Build and install the toolchain (requires write+create permissions for
-      $INSTALL_DIR.)
+    # 3. Build and install the toolchain (requires write+create permissions for $INSTALL_DIR.)
     sh build-toolchain.sh $INSTALL_DIR
 
 ## File and directory structure
@@ -43,16 +42,16 @@ latest supported upstream GCC toolchain for bare-metal 32-bit and 64-bit applica
 The base infrastructure for building compilation toolchains consists of two scripts
 and a directory holding configuration files:
 
-* `get-toolchain.sh`: script in charge of obtaining the source code and
-extracting the correct code baselines
-* `build-toolchain.sh`: script in charge of building and installing the
+ * `get-toolchain.sh`: script in charge of obtaining the source code and
+extracting the correct code baselines.
+ * `build-toolchain.sh`: script in charge of building and installing the
 different toolchain components in suitable order.
-* `config/`: directory containing the configuration files for the various configurations.
+ * `config/`: directory containing the configuration files for the various configurations.
 
 In the process of building the toolchain, two new directory trees are created
 under the current working directory:
 
- * `src/`: source code is fetched and checked out into subdirectories of `src` in
+ * `src/`: Source code is fetched and checked out into subdirectories of `src` in
  the current working directory.
 
  * `build/`: The building of the various components of the toolchain occurs in
@@ -150,10 +149,10 @@ adjusting the values of per-component variables.  Taking `GCC` as an example:
  * `GCC_DIR` defines the location of GCC source code.
  * `GCC_REPO` selects the Git repository to fetch GCC code from. 
  * `GCC_COMMIT` identifies the revision of source code to use: a specific commit,
-   targ, or branch. \
+   tag, or branch. \
    _**NOTE:** If you set `GCC_COMMIT` to the name of a branch, the
    `get-toolchain.sh` will update the local repository to the tip of the remote
-   brach at every invocation._
+   branch at every invocation._
 
  * `GCC_CONFIGURE_OPTS` is the list of options to pass to the configure script. \
    _**NOTE:** Since `GCC_CONFIGURE_OPTS` is a Bourne shell variable, any double-quotes in

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -1,0 +1,159 @@
+`toolchain`: Basic scripts for building RISC-V compiler toolchains
+=============================
+
+# Overview
+
+This directory contains basic scripts for building local instances of CORE-V toolchains.
+The scripts provide the means of fetching the source code and building the executables
+and libraries for well-defined toolchain configurations.  The intention is to
+simplify the processs of building such toolchains and make is as "push-button"
+(and as accessible to CORE-V users) as reasonably possible.
+
+Currently, the scripts support only 'bare metal' toolchain configurations
+intended for hardware verification.  These configurations consist of:
+
+* `binutils`: assembler, linker, and object file utilities
+* `GCC`: the GNU GCC compiler configured for C only
+* `newlib`: an open-source C library suitable for embedded applications.
+
+Several extensions are envisioned:
+
+* Explicit selection of GDB versions
+* Addition of LLVM/Clang compilers
+* Support for Linux-based target environments
+* Addition of full-featured C library implementations
+
+# Getting started
+
+Once the prerequisites (see below) are satisfied, you can fetch and build the
+latest supported upstream GCC toolchain for bare-metal 32-bit and 64-bit applications in just three steps:
+
+    # 1. Select an installation location for the toolchain (e.g., the path in
+      $RISCV).
+    INSTALL_DIR=$RISCV/toolchain
+    
+    # 2. Fetch the source code of the toolchain (assumes Internet access.)
+    sh get-toolchain.sh
+    
+    # 3. Build and install the toolchain (requires write+create permissions for
+      $INSTALL_DIR.)
+    sh build-toolchain.sh $INSTALL_DIR
+
+#  File and directory structure
+
+The base infrastructure for building compilation toolchains consists of two scripts
+and a directory holding configuration files:
+
+* `get-toolchain.sh`: script in charge of obtaining the source code and
+extracting the correct code baselines
+* `build-toolchain.sh`: script in charge of building and installing the
+different toolchain components in suitable order.
+* `config/`: directory containing the configuration files for the various configurations.
+
+In the process of building the toolchain, two new directory trees are created
+under the current working directory:
+
+ * `src/`: source code is fetched and checked out into subdirectories of `src` in
+ the current working directory.
+
+ * `build/`: The building of the various components of the toolchain occurs in
+ subdirectories of `build` in the current working directory.
+
+This directory structure was chosen to keep the source and build directories
+local to the user's workspace while supporting systematic out-of-source-tree
+building of toolchain components.
+
+# Prerequisites
+
+**Disk space:** Approximately 7 GB of disk space are needed to build and install a bare-metal toolchain
+from source code:
+
+ * 5GB are occupied by source code (including Git history);
+ * 1GB is needed for the build space;
+ * 0.4GB is needed for the installed toolchain.
+
+Several **standard packages** are needed to build the GCC-based compiler
+toolchains.  On Debian/Ubuntu, executing the following command should suffice:
+
+    $ sudo apt-get install autoconf automake autotools-dev curl git libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool bc zlib1g-dev
+
+On Fedora/CentOS/RHEL OS, executing the following command should suffice:
+
+    $ sudo yum install autoconf automake git libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo gcc gcc-c++ zlib-devel
+
+On macOS, you can use [Homebrew](http://brew.sh) to install the dependencies:
+
+    $ brew install gawk gnu-sed gmp mpfr libmpc isl zlib
+
+# Building a bare-metal toolchain (Newlib-based)
+
+In order to build a toolchain you need to select a _toolchain configuration_ and
+an _installation location_ (an "install prefix"):
+
+ * the toolchain configuration name must match one of the predefined `config/CONFIG_NAME.sh`
+files under `config` directory.
+ 
+ * the installation location can be an arbitrary path.  It needs not to exist
+yet: any missing directories will be created during the building process. _The user running the
+`build-toolchain.sh` script must have sufficient permissions to create the
+missing directories of the installation location._
+
+Once a configuration name `CONFIG_NAME` and an installation location
+`INSTALL_LOCATION` are chosen, use
+
+    sh get-toolchain.sh CONFIG_NAME
+    # E.g.,
+    # sh get-toolchain.sh gcc-10.2.0-baremetal
+
+to fetch/update the source code and to check out the matching baseline of code.
+
+_**NOTE:** The first invocation of 'get-toolchain.sh' can take approximately half an hour as there
+are 3 GB of data that will be first fetched from remote Git repositiories, then
+unpacked for each of the components.  Subsequent executions take usually between
+5 and 15 seconds as they only fetch new updates from remote servers and check
+out the requested baseline._
+
+If the name of the toolchain configuration is omitted, a default configuration
+will be selected implicitly.  _The default configuration is currently named
+`gcc10-baremetal` and points to the most recent GCC 10.x configuration defined
+under `config/`._
+
+To build the toolchain from the retrieved source baseline, use
+
+    sh build-toolchain.sh CONFIG_NAME INSTALL_DIR
+    # E.g.,
+    # sh build-toolchain.sh gcc-10.2.0-baremetal $RISCV/toolchain
+
+The `build-toolchain.sh` script incorporates fallbacks for several commonly encountered configuration and
+build issues. However, it is not meant to auto-detect major reconfigurations of source
+code such as a change of baseline configuration.  _If/when the source
+configuration was changed, please use the `-f` (or `--force`)
+option to forcibly rebuild the entire toolchain_:
+
+    sh build-toolchain.sh -f CONFIG_NAME INSTALL_DIR
+    # E.g.,
+    # sh build-toolchain.sh -f gcc-10.2.0-baremetal $RISCV/toolchain
+
+### Defining new configurations
+
+Users involved with toolchain validation and development may be interested in
+creating new configurations that cater for specific needs:
+
+ * use of local Git mirrors to enable toolchain development and to shorten
+   Git query times
+ * building of experimental toolchains combining specific versions of individual
+   components.
+
+New configurations can be easily introduced by copying existing
+configuration files in subdirectory `config/` under a different name and
+adjusting the values of per-component variables.  Taking `GCC` as an example:
+
+ * `GCC_DIR` defines the location of GCC source code.
+ * `GCC_REPO` selects the Git repository to fetch GCC code from. 
+ * `GCC_COMMIT` identifies the revision of source code to use: a specific commit,
+   targ, or branch[BR]**NOTE:** If you set `GCC_COMMIT` to the name of a branch, the
+   `get-toolchain.sh` will update the local repository to the tip of the remote
+   brach at every invocation.
+ * `GCC_CONFIGURE_OPTS` is the list of options to pass to the configure script.
+   [BR]**NOTE:** Since `GCC_CONFIGURE_OPTS` is a Bourne shell variable, any double-quotes in
+   the option list must be duly escaped to be correctly handled by the shell.

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -1,7 +1,6 @@
-`toolchain`: Basic scripts for building RISC-V compiler toolchains
-=============================
+# `toolchain`: Basic scripts for building RISC-V compiler toolchains
 
-# Overview
+## Overview
 
 This directory contains basic scripts for building local instances of CORE-V toolchains.
 The scripts provide the means of fetching the source code and building the executables
@@ -23,9 +22,9 @@ Several extensions are envisioned:
 * Support for Linux-based target environments
 * Addition of full-featured C library implementations
 
-# Getting started
+## Getting started
 
-Once the prerequisites (see below) are satisfied, you can fetch and build the
+Once the prerequisites (see [below](#Prerequisites)) are satisfied, you can fetch and build the
 latest supported upstream GCC toolchain for bare-metal 32-bit and 64-bit applications in just three steps:
 
     # 1. Select an installation location for the toolchain (e.g., the path in
@@ -39,7 +38,7 @@ latest supported upstream GCC toolchain for bare-metal 32-bit and 64-bit applica
       $INSTALL_DIR.)
     sh build-toolchain.sh $INSTALL_DIR
 
-#  File and directory structure
+## File and directory structure
 
 The base infrastructure for building compilation toolchains consists of two scripts
 and a directory holding configuration files:
@@ -63,7 +62,7 @@ This directory structure was chosen to keep the source and build directories
 local to the user's workspace while supporting systematic out-of-source-tree
 building of toolchain components.
 
-# Prerequisites
+## Prerequisites
 
 **Disk space:** Approximately 7 GB of disk space are needed to build and install a bare-metal toolchain
 from source code:
@@ -85,7 +84,7 @@ On macOS, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
     $ brew install gawk gnu-sed gmp mpfr libmpc isl zlib
 
-# Building a bare-metal toolchain (Newlib-based)
+## Building a bare-metal toolchain (Newlib-based)
 
 In order to build a toolchain you need to select a _toolchain configuration_ and
 an _installation location_ (an "install prefix"):
@@ -126,15 +125,15 @@ To build the toolchain from the retrieved source baseline, use
 
 The `build-toolchain.sh` script incorporates fallbacks for several commonly encountered configuration and
 build issues. However, it is not meant to auto-detect major reconfigurations of source
-code such as a change of baseline configuration.  _If/when the source
-configuration was changed, please use the `-f` (or `--force`)
+code such as a change of baseline configuration.  _Whenever the source
+configuration is changed, please use the `-f` (or `--force`)
 option to forcibly rebuild the entire toolchain_:
 
     sh build-toolchain.sh -f CONFIG_NAME INSTALL_DIR
     # E.g.,
     # sh build-toolchain.sh -f gcc-10.2.0-baremetal $RISCV/toolchain
 
-### Defining new configurations
+## Defining new configurations
 
 Users involved with toolchain validation and development may be interested in
 creating new configurations that cater for specific needs:
@@ -151,9 +150,11 @@ adjusting the values of per-component variables.  Taking `GCC` as an example:
  * `GCC_DIR` defines the location of GCC source code.
  * `GCC_REPO` selects the Git repository to fetch GCC code from. 
  * `GCC_COMMIT` identifies the revision of source code to use: a specific commit,
-   targ, or branch[BR]**NOTE:** If you set `GCC_COMMIT` to the name of a branch, the
+   targ, or branch. \
+   _**NOTE:** If you set `GCC_COMMIT` to the name of a branch, the
    `get-toolchain.sh` will update the local repository to the tip of the remote
-   brach at every invocation.
- * `GCC_CONFIGURE_OPTS` is the list of options to pass to the configure script.
-   [BR]**NOTE:** Since `GCC_CONFIGURE_OPTS` is a Bourne shell variable, any double-quotes in
-   the option list must be duly escaped to be correctly handled by the shell.
+   brach at every invocation._
+
+ * `GCC_CONFIGURE_OPTS` is the list of options to pass to the configure script. \
+   _**NOTE:** Since `GCC_CONFIGURE_OPTS` is a Bourne shell variable, any double-quotes in
+   the option list must be duly escaped to be correctly handled by the shell._

--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+#############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+#
+# Original Author: Zbigniew Chamski (zbigniew.chamski@invia.fr)
+#
+#############################################################################
+
+# Assumptions:
+# - the required binutils source is in src/binutils-gdb
+# - the required GCC source is in src/gcc
+# - the required newlib is in src/newlib
+# - the user invoking this script has sufficient permissions
+#   to create/populate the installation directory.
+# - there are no restrictions on the parallelism of the build process
+#   ("make -j" without an explicit job limit causes no significant harm)
+#
+# Builds of individual tools are performed under the matching
+# build/... subdirectories
+
+# Helper function to print usage information.
+function print_usage()
+{
+    echo Usage:
+    echo "  $SHELL $0 [-f|--force] [CONFIG_NAME] INSTALL_PREFIX"
+    echo ""
+    echo "  -f,--force       Rebuild toolchain from scratch (remove build dirs,"
+    echo "                     configure and build again.)"
+    echo "  CONFIG_NAME      Use configuration from file config/CONFIG_NAME.sh"
+    echo "                     (default: '$CONFIG_NAME')"
+    echo "  INSTALL_PREFIX   Path where the toolchain should be installed"
+    echo "                     (relative paths will be converted to absolute ones,"
+    echo "                     missing parent directories will be created as needed.)"
+}   
+
+# Helper function to parse the cmdline args
+# Takes the complete list of positional args, drops them as they get parsed.
+function parse_cmdline()
+{
+    # "Force rebuild" mode: try before any file/directory names.
+    # Valid only with 2+ cmdline args.
+    if [ $# -ge 2 ]; then
+	if [ $1 = "-f" -o $1 = "--force" ]; then
+	    FORCE_REBUILD=yes
+	    shift
+	fi
+    fi
+
+    # Check for the config name.  Valid only with 2+ cmdline args left.
+    if [ $# -ge 2 ]; then
+	CONFIG_NAME=$1
+	shift
+    fi
+
+    # Check for the installation prefix.  Must exist after dropping previous args.
+    if [ $# -eq 1 ]; then
+	# Resolve the path to an absolute one (it needs NOT to exist yet.)
+	PREFIX=`readlink -m "$1"`
+	shift
+    fi
+
+    # Any remaining arg past the prefix means an error.
+    if [ $# -gt 0 ]; then
+	echo "*** Excess arguments past INSTALL_PREFIX: please correct the command line!"
+	echo ""
+	print_usage
+	exit 12
+    fi
+}
+
+# ======== Default settings: GCC 10 baremetal, no forced rebuild ========
+# - toolchain configuration.
+#   NOTE: config/$CONFIG_NAME.sh can be a symbolic link.
+CONFIG_NAME="gcc10-baremetal"
+
+# - rebuild mode
+FORCE_REBUILD=no
+
+# The INSTALL_PREFIX argument is required
+if [ $# -lt 1 ]; then
+    echo "*** Please specify the installation prefix of the toolchain!"
+    echo ""
+    print_usage;
+    exit 11
+fi
+
+# ======== Parse the command line.  Drop each successfully parsed arg. ========
+echo "### Parsing the cmdline..."
+parse_cmdline $@
+
+# ======== Check if config file exists, and load it if it does ========
+# Check for the presence of source code and build configuration.
+CONFIG_FILE="config/$CONFIG_NAME.sh"
+
+if [ -f $CONFIG_FILE ]; then
+    # File present: read the settings.
+    . $CONFIG_FILE
+else
+    echo "*** Configuration file '$CONFIG_FILE' missing!"
+    echo ""
+    print_usage
+    exit 13
+fi
+
+# ======== Actual build process ========
+
+# Force rebuilding if asked to: remove all build directories.
+[ $FORCE_REBUILD = "yes" ] && rm -rf build/{binutils-gdb,gcc,newlib}
+
+# Overall build policy: try to be as push-button as possible...
+# - If a Makefile already exists, do not configure again - just build+install.
+# - If there is no Makefile, run configure, then build and install.
+# - If the first configure attempt failed try making 'clean' and 'distclean'
+#   targets.
+# - In case of build error in GCC once configured, remove the target-specific
+#   build subdirectories and try making again.
+# - binutils and GCC are built with CFLAGS and CXXFLAGS set to "-O2"
+#   ("production" mode: no debug, stripping disabled = 10x smaller binaries).
+# - CFLAGS and CXXFLAGS are left unset for newlib.
+
+# Disable debug support to reduce size of executables and speed up their launching.
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
+
+# Configure and build binutils (required by GCC).
+[ -d build/binutils-gdb ] || mkdir -p build/binutils-gdb
+cd build/binutils-gdb
+[ -f Makefile ] || \
+    ../../$BINUTILS_DIR/configure $BINUTILS_CONFIGURE_OPTS || \
+    { [ -f Makefile ] && make clean && make distclean && \
+	  ../../$BINUTILS_DIR/configure $BINUTILS_CONFIGURE_OPTS || \
+	      { echo "Could not configure binutils-gdb, bailing out!" ; \
+		exit 2 ; } ; } && \
+    make -j all && make install || \
+	{ echo "*** Could not build binutils, bailing out!" ; exit 2; }
+cd -
+									
+# Configure and build GCC (required by newlib).
+# If an initial configure failed (e.g., due to a change in PREFIX),
+# try making 'distclean' target and configuring again.
+# The target-specific subdirectories configured during *build*
+# are simply removed in case of build error, and 'make all' is
+# then restarted.
+[ -d build/gcc ] || mkdir -p build/gcc
+cd build/gcc
+[ -f Makefile ] || \
+    ../../$GCC_DIR/configure $GCC_CONFIGURE_OPTS || \
+    { [ -f Makefile ] && make clean && make distclean && \
+	  make -C libcc1 distclean && \
+	  ../../$GCC_DIR/configure $GCC_CONFIGURE_OPTS || \
+	      { echo "Could not configure GCC, bailing out!" ; \
+		exit 2 ; } ; } && \
+	make -j all || { rm -rf $TARGET && \
+			     make -j all ; } && make install || \
+	{ echo "*** Could not build GCC (even after removing target dirs), bailing out!" ; exit 2; }
+cd -
+
+# Unset the variables forced for binutils and GCC builds.
+unset CFLAGS CXXFLAGS
+
+# Configure and build newlib.
+# We need the path to the newly installed tools
+# when running 'configure' and building newlib.
+
+# If an initial configure failed, try making 'distclean' target
+# and configuring again.
+[ -d build/newlib ] || mkdir -p build/newlib
+cd build/newlib
+export PATH="$PREFIX/bin:$PATH"
+[ -f Makefile ] || \
+    ../../$NEWLIB_DIR/configure $NEWLIB_CONFIGURE_OPTS || \
+    { [ -f Makefile ] && make clean && make distclean && \
+	  ../../$NEWLIB_DIR/configure $NEWLIB_CONFIGURE_OPTS || \
+	      { echo "Could not configure newlib, bailing out!" ; \
+		exit 2 ; } ; } && \
+    make -j all && make install || \
+	{ echo "*** Could not build newlib, bailing out!" ; exit 2; }
+cd -
+								       
+# Exit happily.
+exit 0

--- a/toolchain/config/gcc-10.1.0-baremetal.sh
+++ b/toolchain/config/gcc-10.1.0-baremetal.sh
@@ -1,0 +1,66 @@
+#############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+#
+# Original Author: Zbigniew Chamski (zbigniew.chamski@invia.fr)
+#
+#############################################################################
+
+# Name of the target to use for the toolchain.
+export TARGET=riscv-none-elf
+
+# ======= Source code setup: path, repo, commit, configure options ========
+
+# Each *_COMMIT variable can designate any valid 'commit-ish' entity:
+# typically a tag, a commit or the output of "git describe" of a Git tree.
+
+# Binutils
+BINUTILS_DIR=src/binutils-gdb
+BINUTILS_REPO=https://sourceware.org/git/binutils-gdb.git
+# Use the first commit past the 'bintuils-2_34' tag.
+# The commit at the tag does not build with 'make all ; make install',
+# and a binutils-only approach with 'make all-binutils ; make install-binutils'
+# does not work for binutils 2.35 + GCC 10.2.0.
+BINUTILS_COMMIT=binutils-2_34-1-g871ac467f5
+BINUTILS_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+ 	--disable-nls \
+ 	--disable-werror"
+
+# GCC
+GCC_DIR=src/gcc
+GCC_REPO=https://github.com/gcc-mirror/gcc.git
+GCC_COMMIT=releases/gcc-10.1.0
+
+GCC_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+	--enable-languages=c,lto \
+	--disable-libssp \
+	--disable-libgomp \
+	--disable-libmudflap"
+
+# newlib
+NEWLIB_DIR=src/newlib
+NEWLIB_REPO=https://sourceware.org/git/newlib-cygwin.git
+NEWLIB_COMMIT=newlib-3.3.0
+
+NEWLIB_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+	--enable-multilib"

--- a/toolchain/config/gcc-10.2.0-baremetal.sh
+++ b/toolchain/config/gcc-10.2.0-baremetal.sh
@@ -1,0 +1,61 @@
+#############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+#
+# Original Author: Zbigniew Chamski (zbigniew.chamski@invia.fr)
+#
+#############################################################################
+
+# Name of the target to use for the toolchain.
+export TARGET=riscv-none-elf
+
+# ======= Source code setup: path, repo, commit, configure options ========
+
+# Each *_COMMIT variable can designate any valid 'commit-ish' entity:
+# typically a tag, a commit or the output of "git describe" of a Git tree.
+
+# Binutils
+BINUTILS_DIR=src/binutils-gdb
+BINUTILS_REPO=https://sourceware.org/git/binutils-gdb.git
+BINUTILS_COMMIT=binutils-2_35
+BINUTILS_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+ 	--disable-nls \
+ 	--disable-werror"
+
+# GCC
+GCC_DIR=src/gcc
+GCC_REPO=https://github.com/gcc-mirror/gcc.git
+GCC_COMMIT=releases/gcc-10.2.0
+GCC_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+	--enable-languages=c \
+	--disable-libssp \
+	--disable-libgomp \
+	--disable-libmudflap"
+
+# newlib
+NEWLIB_DIR=src/newlib
+NEWLIB_REPO=https://sourceware.org/git/newlib-cygwin.git
+NEWLIB_COMMIT=newlib-3.3.0
+
+NEWLIB_CONFIGURE_OPTS="\
+	--prefix=$PREFIX \
+	--target=$TARGET \
+	--enable-multilib"

--- a/toolchain/config/gcc10-baremetal.sh
+++ b/toolchain/config/gcc10-baremetal.sh
@@ -1,0 +1,1 @@
+gcc-10.2.0-baremetal.sh

--- a/toolchain/get-toolchain.sh
+++ b/toolchain/get-toolchain.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+#############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+#
+# Original Author: Zbigniew Chamski (zbigniew.chamski@invia.fr)
+#
+#############################################################################
+
+# Prerequisites:
+#
+# - autotools
+# - GNU make
+# - flex (which flex)
+# - bison (which bison)
+# - isl
+# - gmp
+# - mpz
+# - mpc
+# - texinfo
+# - 15 GB of disk space
+
+# Helper function to print usage information.
+function print_usage()
+{
+    echo Usage:
+    echo "        your-favorite-shell $0 [CONFIG_NAME]"
+    echo ""
+    echo "        CONFIG_NAME    Use configuration from file config/CONFIG_NAME.sh"
+}   
+
+# Helper function to parse the cmdline args.
+# Takes the complete list of positional args as input, drops them locally as they get parsed.
+function parse_cmdline()
+{
+    # There must be exactly one positional arg.
+    if [ $# -gt 1 ]; then
+	echo "*** Incorrect number of cmdline arguments ($#), exiting!"
+	echo ""
+	print_usage
+	exit 11
+    fi
+	
+    # The only, optional arg is supposed to be the config name.
+    if [ $# -eq 1 ]; then
+	CONFIG_NAME=$1
+	shift
+    fi
+}
+
+# ======== Default settings: GCC 10 baremetal ========
+# - toolchain configuration
+#   NOTE: config/$CONFIG_NAME.sh can be a symbolic link.
+CONFIG_NAME="gcc10-baremetal"
+
+# ======== Parse the command line ========
+parse_cmdline $@
+
+# ======== Read configuration information =========
+# Check for the presence of source code and build configuration file.
+
+CONFIG_FILE="config/$CONFIG_NAME.sh"
+
+if [ -f $CONFIG_FILE ]; then
+    # File present: read the settings.
+    . $CONFIG_FILE
+else
+    echo "*** Configuration file '$CONFIG_FILE' missing, bailing out!"
+    echo ""
+    print_usage
+    exit 12
+fi
+# ========= Populate/update the directories =========
+
+# Hook for the future tarball-only option
+# if [ $# -lt 2 -o $1 == "git"]; then
+#    # populate directories from Git
+# else
+#    # populate directories from tarballs
+# fi
+
+# Overall directory infrastructure: make sure `pwd`/src exists.
+[ ! -d src ] && mkdir src
+
+# All Git-based source trees are handled in the same way.
+# Positional args:
+# - $1: the Git repository to use
+# - $2: the local directory for the source code
+# - $3: the actual commit to check out (SHA1, tag, etc.)
+function setup_sources_from_git()
+{
+    # make sure the source directory exists and is populated
+    # with Git information.  If a stale non-Git directory exits,
+    # remove it unless it is write-protected.
+    [ -d $2 -a -d $2/.git ] || \
+    { rm -rf $2 &&  \
+	  git clone $1 $2 ; }
+
+    # Fetch any possible updates and check out the required revision.
+    cd $2
+    git fetch origin
+    git checkout $3
+    cd -
+}
+
+# Binutils
+setup_sources_from_git $BINUTILS_REPO $BINUTILS_DIR $BINUTILS_COMMIT
+
+# GCC
+setup_sources_from_git $GCC_REPO $GCC_DIR $GCC_COMMIT
+
+# Newlib
+setup_sources_from_git $NEWLIB_REPO $NEWLIB_DIR $NEWLIB_COMMIT
+
+# Exit happily.
+exit 0


### PR DESCRIPTION
The purpose of this pull request (PR) is to provide members involved in Core-V development with means of building well-defined compiler toolchains for HW verification.  The PR introduces scripts for fetching toolchain source code from servers *external* to core-v-sw repository and for building the toolchains from source, together with two examples of configuration files.

These "external" servers can be any Git servers visible from a member's environment, either publicly available (as in the examples provided), or internal to the member's organization. 

File `toolchain/README.md` explains in detail the purpose, the structure and the usage of the scripts, and lists the enhancements envisioned at this point.

Last but not least: The location of scripts proposed in the pull request is by no means definitive.  Feel free to recommend/define a better one, so that the scripts can settle there for the foreseeable future.
