### PR TITLE
Updated agenda for meeting on 8 March 2021

### DIFF
--- a/meetings/2021/2021-03-08-agenda.md
+++ b/meetings/2021/2021-03-08-agenda.md
@@ -41,9 +41,9 @@ We are recording attendance at meetings, so OpenHW Group can track membership in
 
   - see agenda item [Platform and core models for software engineers](#platform-and-core-models-for-software-engineers).
 
-## Report back from TWG
+## Report back from TWG (5 minutes allocated)
 
-Report by the chair and Duncan Bees (5 minutes allocated).
+Report by the chair and Duncan Bees.
 
 - software models
 
@@ -59,23 +59,32 @@ Each project leader is asked to present any key issues for which community input
 - CORE-V Clang/LLVM - Philipp Krones and André Szintoff
 - CORE-V Verilator modeling (HW TG project) - Alfredo Herrera
 
-## Platform and core models for software engineers (15 minutes allocated)
+## OpenHW Day: 1 April 2021 (10 minutes allocated)
+
+OpenHW day is part of Paris RISC-V week. We have 90 minutes to showcase the work of the Software Task Group from 11:00-12:30 CET on Thursday 1 April. The focus is on demoing rather than just talking. As a starting point for discussion, I'd like to suggest the following program:
+
+- 11:00 GCC & LLVM
+- 11:15 FreeRTOS
+- 11:30 IDEs (Eclipse & PlatformIO)
+- 11:45 Software simulation models (Verilator and OVPSim)
+- 12:00 Future projects
+- 12:15 Q&A
+
+I hope project leads will be able to demo there work. I appreciate some projects are at an early stage. I also appreciate that for some it will be quite early in the morning!
+
+## Platform and core models for software engineers (10 minutes allocated)
 
 (continuation of last month's agenda item)
 
 Within the remit of the Software TG is provision of models for use by software engineers.  Last month we agreed to support the Verilator modeling project for software engineers requiring a cycle accurate model.
 
-This month we wish to resolve the solution for our remaining software modeling needs.  We started discussing a proposal to use OVPSim from Imperas for all these needs.
+This month we wish to resolve the solution for our remaining software modeling needs.  We started discussing a proposal to use OVPSim from Imperas for all these needs. This agenda item is to bring that discussion to a conclusion.
 
-Since that meeting, the possiblity of using [Renode](https://renode.io/) has been raised.  I have asked an OpenHW Group member who has used Renode for CORE-V to present their experience.  If we wish to pursue this, it will need someone to step forward to lead the project and the project to be endorsed by the Software TG.
-
-At the end of this discussion we should reach a decision on what to use for our software modeling needs.
-
-## PlatformIO project proposal (15 minutes allocated)
+## PlatformIO project proposal (5 minutes allocated)
 
 We have a preliminary project proposal in preparation by Ivan Kravets.  In the first instance this will be a standalone PlatformIO implementation for CORE-V, but the long term objective is to integrate with the Eclipse CDT work of our existing IDE project.
 
-Ivan will present his draft proposal for endorsement by the Software Task Group.
+Ivan will present progress so far on preparing this proposal.
 
 ## Hardware abstraction layer (10 minutes allocated)
 


### PR DESCRIPTION
Files changed:

	* meetings/2021/2021-03-08-agenda.md: Add OpenHW day, remove
	Renode from modeling discussion, shorten PlatformIO discussion.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>