### PR TITLE
Update CVA6 status in Clang-LLVM project report of 14 June 2021.

### DIFF
--- a/projects/clang-llvm/2021/monthly-report-2021-06-14.md
+++ b/projects/clang-llvm/2021/monthly-report-2021-06-14.md
@@ -5,7 +5,7 @@
 ### Key activities
 
 * CVA6
-  * None
+  * Check status of Clang+LLVM+LLD wrt. core-v-verif tests; key issues: floating-point, out-of-bound relocations
 
 * CV32E40P
   * Port hardware loop code generation
@@ -25,7 +25,9 @@
 ### Planned activities for coming month
 
 * CVA6:
-  * None
+  * Finalise LLVM / core-v-verif evaluation
+  * Automate builds of the toolchain (Thales, externally accessible)
+  * Basic benchmarking (performance, code size)
 
 * CV32E40P:
   * Do automated builds of the toolchain (Embecosm)


### PR DESCRIPTION
Update by @PicoPET 