### PR TITLE
Add draft agenda for Software TG meeting of 10 January 2022.

### DIFF
--- a/meetings/2022/2022-01-10-agenda.md
+++ b/meetings/2022/2022-01-10-agenda.md
@@ -1,0 +1,88 @@
+# OpenHW Software Task Group Meeting Agenda
+
+Monday 10 January 2022
+
+- 07:00-08:00 Pacific Time
+- 10:00-11:00 East Coast Time
+- 14:00-15:00 UTC
+- 15:00-16:00 UK Time
+- 16:00-17:00 Central European Time
+- 22:00-23:00 Beijing Time
+
+## Location
+
+Zoom meeting.
+
+- [us02web.zoom.us/j/85194416761?pwd=M2kwRzNCUG82UFlJT0NMbnJPSXBCZz09](https://us02web.zoom.us/j/85194416761?pwd=M2kwRzNCUG82UFlJT0NMbnJPSXBCZz09)
+- Meeting ID: 851 9441 6761
+- Find your local number: [us02web.zoom.us/u/kuUW3yscL](https://us02web.zoom.us/u/kuUW3yscL)
+
+# Agenda topics
+
+## Register of attendance and introductions
+
+We are recording attendance at meetings, so OpenHW Group can track membership in accordance with article 4 of the membership agreement. This matters particularly when email ballots are held, to ensure the voters represent member organizations who are active on the group. The attendance records are can be seen in the [program](https://github.com/openhwgroup/core-v-docs/tree/master/program) directory of the [core-v-docs repository](https://github.com/openhwgroup/core-v-docs).
+
+## Review of actions (15 minutes allocated)
+
+- **Olive Zhao** to convene a standalone meeting to discuss requirements for the HAL, which we bring in as many HAL experts as possible.
+
+- **Jessica Mills** to roll forward GCC to include the B extension support.
+
+- **Jessica Mills** to take CORE-V GNU Tools project through Project Launch gate.
+
+- **Duncan Bees** to have conversation with Robert Balas, Shterana Shopova and Richard Barry about moving CORE-V FreeRTOS project to Project Launch gate.
+
+- **Jeremy Bennett** to take CORE-V Verilator Modeling project through Project Launch gate.
+
+- **Duncan Bees** and **Jeremy Bennett** to identify speakers who can inform our discussion on AI.
+
+- **Greg Martin** to review issues [#149](https://github.com/openhwgroup/core-v-mcu/issues/149) and [#115](https://github.com/openhwgroup/core-v-mcu/issues/115) raised by Robert Balas for the FreeRTOS project.
+
+  - Action held open pending confirmation of resolution.
+
+## Report back from TWG (5 minutes allocated)
+
+Duncan Bees to report.
+
+## CORE-V GNU Tools project lead (5 minutes allocated)
+
+I have to report that Jessica Mills has left Embecosm and has stood down as GNU Tools project lead. I should like to thank Jessica for her contribution since the start of this project.
+
+We need a new project lead for this project.  Because of the target of upstreaming the GNU tools as a vendor specific target we need an engineer familiar with the process of upstreaming to GNU projects.  I hope to present a candidate for the role at the meeting.
+
+## Reports from current projects (30 minutes allocated)
+
+Active projects under the Software Task Group will have provided a written report in advance. We also have one project under the Hardware Task Group which also reports into us.
+
+Each project leader is asked to present any key issues for which community input frm the meeting is required. Since this is the first meeting of the new calendar year, I'd like each project leader to review the progress made over the past 12 months. Project leaders will also take any questions.
+
+- CORE-V IDE - Alexander Fedorov
+- CORE-V GNU Tools - TBC
+- CORE-V FreeRTOS - Robert Balas and Shteryana Shopova
+- CORE-V Clang/LLVM - Philipp Krones and Zbigniew Chamski
+- Hardware Abstraction Layer - Yunhain Shang and Olive Zhao
+- Software Development Kit - Hugh O'Keefe
+- CORE-V Verilator modeling (HW TG project) - Jeremy Bennett
+
+## AOB
+
+## Dates for future meetings
+
+The task group meets monthly at 07:00 Pacific Time on the second Monday of the month.
+
+- 14 Feb 2022
+- 14 Mar 2022
+- 11 Apr 2022
+- 9 May 2022
+- 13 Jun 2022
+- 11 Jul 2022
+- 8 Aug 2022
+- 12 Sep 2022
+- 10 Oct 2022
+- 14 Nov 2022
+
+Noting how busy December can be, I have again proposed no meeting in that month.
+
+Jeremy Bennett, Chair\
+Yunhai Shang, Vice-Chair


### PR DESCRIPTION
Files changed:

	* meetings/2022/2022-01-10-agenda.md: Created.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>