### PR TITLE
Update to Software TG agenda for 8 Aug 2022

### DIFF
--- a/meetings/2022/2022-08-08-agenda.md
+++ b/meetings/2022/2022-08-08-agenda.md
@@ -63,11 +63,17 @@ We are recording attendance at meetings, so OpenHW Group can track membership in
 
   - carried forward
 
+## Project leads (5 minutes allocated)
+
+As noted last month, Charlie Keaney of Embecosm has volunteered to take over maintenance and development of the 32-bit CORE-V Clang/LLVM.  In the absence of any other candidates, the chair proposes that Charlie be appointed CORE-V Clang/LLVM lead.
+
+Maxim Blinov is leaving Embecosm to return to academic studies, and will therefore step down as GNU Tools project lead. Anyone with GNU Tools experience interested in taking over leadership of this project, including running the weekly conference calls is invited to put their name forward the chair, with a view to appointing a lead at our next meeting.
+
 ## Report back from TWG (5 minutes allocated)
 
 Duncan Bees to report.
 
-## Reports from current projects (20 minutes allocated)
+## Reports from current projects (15 minutes allocated)
 
 Active projects under the Software Task Group will have provided a written report in advance (seet the [project specific directories](https://github.com/openhwgroup/core-v-sw/blob/master/projects) of the [core-v-sw](https://github.com/openhwgroup/core-v-sw) repository. We also have one project under the Hardware Task Group which also reports into us.
 


### PR DESCRIPTION
Files changed:

	* meetings/2022/2022-08-08-agenda.md: Add section to consider
	project leads.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>