### PR TITLE
Builtin spec updated to version 0.4.

### DIFF
--- a/specifications/corev-builtin-spec.md
+++ b/specifications/corev-builtin-spec.md
@@ -20,8 +20,8 @@
 - [Listing of immediate branch builtins (`xcvbi`)](#listing-of-immediate-branch-builtins-xcvbi)
 - [Listing of post-indexed and register-indexed memory access builtins (`xcvmem`)](#listing-of-post-indexed-and-register-indexed-memory-access-builtins-xcvmem)
 - [Listing of miscellaneous ALU builtins (`xcvalu`)](#listing-of-miscellaneous-alu-builtins-xcvalu)
-  - [ALU builtins for 32-bit cores](#alu-builtins-for-32-bit-cores)
-  - [ALU builtins for 64-bit cores](#alu-builtins-for-64-bit-cores)
+  - [ALU builtins (32-bit)](#alu-builtins-32-bit)
+  - [ALU builtins (64-bit)](#alu-builtins-64-bit)
 - [Listing of PULP 8/16-bit SIMD builtins (`xcvsimd`)](#listing-of-pulp-816-bit-simd-builtins-xcvsimd)
   - [SIMD ALU operations (32-bit)](#simd-alu-operations-32-bit)
   - [SIMD ALU operations (64-bit)](#simd-alu-operations-64-bit)
@@ -36,11 +36,11 @@
   - [SIMD complex number operations (32-bit)](#simd-complex-number-operations-32-bit)
   - [SIMD complex number operations (64-bit)](#simd-complex-number-operations-64-bit)
 - [Listing of PULP bit manipulation builtins (`xcvbitmanip`)](#pulp-bit-manipulation-builtins-for-32-bit-cores)
-  - [PULP bit manipulation builtins for 32-bit cores](#pulp-bit-manipulation-builtins-for-32-bit-cores)
-  - [PULP bit manipulation builtins for 64-bit cores](#pulp-bit-manipulation-builtins-for-64-bit-cores)
+  - [PULP bit manipulation builtins (32-bit)](#pulp-bit-manipulation-builtins-32-bit)
+  - [PULP bit manipulation builtins (64-bit)](#pulp-bit-manipulation-builtins-64-bit)
 - [Listing of event load word builtins (`xcvelw`)](#listing-of-event-load-word-builtins-xcvelw)
-  - [Event load word builtins for 32-bit cores](#event-load-word-builtins-for-32-bit-cores)
-  - [Event load word builtins for 64-bit cores](#event-load-word-builtins-for-64-bit-cores)
+  - [Event load word builtins (32-bit)](#event-load-word-builtins-32-bit)
+  - [Event load word builtins (64-bit)](#event-load-word-builtins-64-bit)
 
 ## History
 
@@ -54,6 +54,7 @@
 |             |         | - pseudo-overloading to allow 32- and 64-bit support; |
 | 13 Feb 2023 | 0.3     | Third draft after feedback from the GCC               |
 |             |         | implementation team.                                  |
+| 16 Feb 2023 | 0.4     | Fourth draft incorporating Pascal Gouedo comments.    |
 
 ## Executive Summary
 
@@ -162,6 +163,9 @@ There are no builtin functions for hardware loops.
 
 **Applicability.** 32-bit cores.
 
+- [`int32_t __builtin_riscv_cv_mac_mac`](#int32_t-__builtin_riscv_cv_mac_mac-int32_t-x-int32_t-y-int32_t-z)
+- [`int32_t __builtin_riscv_cv_mac_msu`](#int32_t-__builtin_riscv_cv_mac_msu-int32_t-x-int32_t-y-int32_t-z)
+
 The ordering of arguments mirrors the standard C function `fma`
 
 For 32-bit architectures, we have the following instructions providing 32-bit x 32-bit multiply-accumulate.
@@ -199,6 +203,15 @@ It is anticipated that 64-bit cores may wish to define 64-bit x 64-bit operation
 ### 16-bit x 16-bit multiplication
 
 **Applicability.** 32-bit cores
+
+- [`uint32_t __builtin_riscv_cv_mac_muluN`](#uint32_t-__builtin_riscv_cv_mac_muluN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_mulhhuN`](#uint32_t-__builtin_riscv_cv_mac_mulhhuN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_mulsN`](#int32_t-__builtin_riscv_cv_mac_mulsN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_mulhhsN`](#int32_t-__builtin_riscv_cv_mac_mulhhsN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_muluRN`](#uint32_t-__builtin_riscv_cv_mac_muluRN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_mulhhuRN`](#uint32_t-__builtin_riscv_cv_mac_mulhhuRN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_mulsRN`](#int32_t-__builtin_riscv_cv_mac_mulsRN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_mulhhsRN`](#int32_t-__builtin_riscv_cv_mac_mulhhsRN-uint32_t-x-uint32_t-y-const-uint8_t-shft)
 
 Even though these are 16-bit operands, we pass them as 32-bit, because the different instructions select different 16-bit words within the 32-bit word.  The 32-bit words are always passed unsigned, even when the operations are signed, since we are extracting half words, from a 32-bit entity.  However the results from signed operations are 32-bit signed values.
 
@@ -315,6 +328,15 @@ It is anticipated that 64-bit cores may wish to define 32-bit x 32-bit operation
 ### 16-bit x 16-bit multiply-accumulate
 
 **Applicability.** 32-bit cores.
+
+- [`uint32_t __builtin_riscv_cv_mac_macuN`](#uint32_t-__builtin_riscv_cv_mac_macuN-uint32_t-x-uint32_t-y-uint32_t-z-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_machhuN`](#uint32_t-__builtin_riscv_cv_mac_machhuN-uint32_t-x-uint32_t-y-uint32_t-z-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_macsN`](#int32_t-__builtin_riscv_cv_mac_macsN-uint32_t-x-uint32_t-y-int32_t-z-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_machhsN`](#int32_t-__builtin_riscv_cv_mac_machhsN-uint32_t-x-uint32_t-y-int32_t-z-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_macuRN`](#uint32_t-__builtin_riscv_cv_mac_macuRN-uint32_t-x-uint32_t-y-uint32_t-z-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_mac_machhuRN`](#uint32_t-__builtin_riscv_cv_mac_machhuRN-uint32_t-x-uint32_t-y-uint32_t-z-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_macsRN`](#int32_t-__builtin_riscv_cv_mac_macsRN-uint32_t-x-uint32_t-y-int32_t-z-const-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_mac_machhsRN`](#int32_t-__builtin_riscv_cv_mac_machhsRN-uint32_t-x-uint32_t-y-int32_t-z-const-uint8_t-shft)
 
 Even though these are 16-bit operands, we pass them as 32-bit, because the different instructions select different 16-bit words within the 32-bit word.  The 32-bit words are always passed unsigned, even when the operations are signed, since we are extracting half words, from a 32-bit entity.  However the existing value passed in, and the results from signed operations are 32-bit signed values.
 
@@ -440,9 +462,31 @@ There are no builtins for post-indexed and register-indexed memory access.
 
 ## Listing of miscellaneous ALU builtins (`xcvalu`)
 
-### ALU builtins for 32-bit cores
+### ALU builtins (32-bit)
 
 **Applicability.** 32-bit cores.
+
+- [`int __builtin_abs`](#int-__builtin_abs-int-j)
+- [`int __builtin_riscv_cv_alu_slet`](#int-__builtin_riscv_cv_alu_slet-int32_t--i-int32_t--j)
+- [`int __builtin_riscv_cv_alu_sletu`](#int-__builtin_riscv_cv_alu_sletu-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_alu_min`](#int32_t-__builtin_riscv_cv_alu_min-int32_t-i-int32_t-j)
+- [`uint32_t __builtin_riscv_cv_alu_minu`](#uint32_t-__builtin_riscv_cv_alu_minu-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_alu_max`](#int32_t-__builtin_riscv_cv_alu_max-int32_t-i-int32_t-j)
+- [`uint32_t __builtin_riscv_cv_alu_maxu`](#uint32_t-__builtin_riscv_cv_alu_maxu-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_alu_exths`](#int32_t-__builtin_riscv_cv_alu_exths-int16_t-i)
+- [`uint32_t __builtin_riscv_cv_alu_exthz`](#uint32_t-__builtin_riscv_cv_alu_exthz-uint16_t-i)
+- [`int32_t __builtin_riscv_cv_alu_extbs`](#int32_t-__builtin_riscv_cv_alu_extbs-int8_t-i)
+- [`uint32_t __builtin_riscv_cv_alu_extbz`](#uint32_t-__builtin_riscv_cv_alu_extbz-uint8_t)
+- [`int32_t __builtin_riscv_cv_alu_clip`](#int32_t-__builtin_riscv_cv_alu_clip-int32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_alu_clipu`](#uint32_t-__builtin_riscv_cv_alu_clipu-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_alu_addN`](#int32_t-__builtin_riscv_cv_alu_addN-int32_t-x-int32_t-y-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_alu_adduN`](#uint32_t-__builtin_riscv_cv_alu_adduN-uint32_t-x-uint32_t-y-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_alu_addRN`](#int32_t-__builtin_riscv_cv_alu_addRN-int32_t-x-int32_t-y-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_alu_adduRN`](#uint32_t-__builtin_riscv_cv_alu_adduRN-uint32_t-x-uint32_t-y-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_alu_subN`](#int32_t-__builtin_riscv_cv_alu_subN-int32_t-x-int32_t-y-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_alu_subuN`](#uint32_t-__builtin_riscv_cv_alu_subuN-uint32_t-x-uint32_t-y-uint8_t-shft)
+- [`int32_t __builtin_riscv_cv_alu_subRN`](#int32_t-__builtin_riscv_cv_alu_subRN-int32_t-x-int32_t-y-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_alu_subuRN`](#uint32_t-__builtin_riscv_cv_alu_subuRN-uint32_t-x-uint32_t-y-uint8_t-shft)
 
 **Note:** A number of functions return boolean values.  This specification follows the C convention, where boolean values use the `int` type.
 
@@ -579,18 +623,18 @@ _Generated assembler:_
 
 _Argument/result mapping:_
 
-Case a) where j is constant and can be represented as `(2^(Is2-1)-1)`, where `Is2` is a 5-bit unsigned value
+Case a) where j is constant and `j + 1` is an **exact** power of 2 up to 2^30
 - result: `rD`
 - i: `rs1`
 - j: `Is2` (5-bit unsigned value)
 
 or case b)
 
-- result: `rD`
+- result: `rD` where `j + 1` is not a power of 2
 - i: `rs1`
 - j: `rs2`.
 
-**Note:** In case a), `Is2 = log2 (j + 1) + 1`, where `j + 1` is an exact power of 2 up to 2^30.
+**Note:** In case a), `Is2 = log2 (j + 1) + 1`.
 
 _Generated assembler:_
 
@@ -603,11 +647,24 @@ or case b)
         cv.clipr  rD,rs1,rs2
 ```
 
+_Examples:_
+
+`__builtin_riscv_cv_alu_clip (i, 15)` would result in
+```gas
+        cv.clip rD,rs1,5
+```
+
+`__builtin_riscv_cv_alu_clip (i, 10)` would result in
+```gas
+        c.lui rs2,10
+        cv.clipr rD,rs1,rs2
+```
+
 #### `uint32_t __builtin_riscv_cv_alu_clipu (uint32_t i, uint32_t j)`
 
 _Argument/result mapping:_
 
-Case a) where j is constant and can be represented as `(2^(Is2-1)-1)`, where `Is2` is a 5-bit unsigned value
+Case a) where j is constant and  and `j + 1` is an **exact** power of 2 up to 2^30
 - result: `rD`
 - i: `rs1`
 - j: `Is2` (5-bit unsigned value)
@@ -618,7 +675,7 @@ or case b)
 - i: `rs1`
 - j: `rs2`.
 
-**Note:** In case a), `Is2 = log2 (j + 1) + 1`, where `j + 1` is an exact power of 2 up to 2^30.
+**Note:** In case a), `Is2 = log2 (j + 1) + 1`.
 
 _Generated assembler:_
 
@@ -629,6 +686,19 @@ Case a)
 or case b)
 ```gas
         cv.clipur  rD,rs1,rs2
+```
+
+_Examples:_
+
+`__builtin_riscv_cv_alu_clip (i, 255)` would result in
+```gas
+        cv.clipu rD,rs1,9
+```
+
+`__builtin_riscv_cv_alu_clip (i, 200)` would result in
+```gas
+        c.lui rs2,200
+        cv.clipur rD,rs1,rs2
 ```
 
 #### `int32_t __builtin_riscv_cv_alu_addN (int32_t x, int32_t y, uint8_t shft)`
@@ -839,7 +909,7 @@ or case b)
         cv.subuRNr  rD,rs1,rs2
 ```
 
-### ALU builtins for 64-bit cores
+### ALU builtins (64-bit)
 
 **Applicability.** 64-bit cores.
 
@@ -850,6 +920,67 @@ It is anticipated that 64-bit cores may wish to define ALU operations by analogy
 ### SIMD ALU operations (32-bit)
 
 **Applicability.** 32-bit cores.
+
+- [`uint32_t __builtin_riscv_cv_simd_add_h`](#uint32_t-__builtin_riscv_cv_simd_add_h-uint32_t-i-uint32_t-j-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_simd_add_b`](#uint32_t-__builtin_riscv_cv_simd_add_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_add_sc_h`](#uint32_t-__builtin_riscv_cv_simd_add_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_add_sc_b`](#uint32_t-__builtin_riscv_cv_simd_add_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sub_h`](#uint32_t-__builtin_riscv_cv_simd_sub_h-uint32_t-i-uint32_t-j-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_simd_sub_b`](#uint32_t-__builtin_riscv_cv_simd_sub_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sub_sc_h`](#uint32_t-__builtin_riscv_cv_simd_sub_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sub_sc_b`](#uint32_t-__builtin_riscv_cv_simd_sub_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avg_h`](#uint32_t-__builtin_riscv_cv_simd_avg_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avg_b`](#uint32_t-__builtin_riscv_cv_simd_avg_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avg_sc_h`](#uint32_t-__builtin_riscv_cv_simd_avg_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avg_sc_b`](#uint32_t-__builtin_riscv_cv_simd_avg_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avgu_h`](#uint32_t-__builtin_riscv_cv_simd_avgu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avgu_b`](#uint32_t-__builtin_riscv_cv_simd_avgu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avgu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_avgu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_avgu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_avgu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_min_h`](#uint32_t-__builtin_riscv_cv_simd_min_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_min_b`](#uint32_t-__builtin_riscv_cv_simd_min_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_min_sc_h`](#uint32_t-__builtin_riscv_cv_simd_min_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_min_sc_b`](#uint32_t-__builtin_riscv_cv_simd_min_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_minu_h`](#uint32_t-__builtin_riscv_cv_simd_minu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_minu_b`](#uint32_t-__builtin_riscv_cv_simd_minu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_minu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_minu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_minu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_minu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_max_h`](#uint32_t-__builtin_riscv_cv_simd_max_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_max_b`](#uint32_t-__builtin_riscv_cv_simd_max_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_max_sc_h`](#uint32_t-__builtin_riscv_cv_simd_max_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_max_sc_b`](#uint32_t-__builtin_riscv_cv_simd_max_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_maxu_h`](#uint32_t-__builtin_riscv_cv_simd_maxu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_maxu_b`](#uint32_t-__builtin_riscv_cv_simd_maxu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_maxu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_maxu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_maxu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_maxu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_srl_h`](#uint32_t-__builtin_riscv_cv_simd_srl_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_srl_b`](#uint32_t-__builtin_riscv_cv_simd_srl_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_srl_sc_h`](#uint32_t-__builtin_riscv_cv_simd_srl_sc_h-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_srl_sc_b`](#uint32_t-__builtin_riscv_cv_simd_srl_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sra_h`](#uint32_t-__builtin_riscv_cv_simd_sra_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sra_b`](#uint32_t-__builtin_riscv_cv_simd_sra_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sra_sc_h`](#uint32_t-__builtin_riscv_cv_simd_sra_sc_h-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sra_sc_b`](#uint32_t-__builtin_riscv_cv_simd_sra_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sll_h`](#uint32_t-__builtin_riscv_cv_simd_sll_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sll_b`](#uint32_t-__builtin_riscv_cv_simd_sll_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sll_sc_h`](#uint32_t-__builtin_riscv_cv_simd_sll_sc_h-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sll_sc_b`](#uint32_t-__builtin_riscv_cv_simd_sll_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_or_h`](#uint32_t-__builtin_riscv_cv_simd_or_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_or_b`](#uint32_t-__builtin_riscv_cv_simd_or_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_or_sc_h`](#uint32_t-__builtin_riscv_cv_simd_or_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_or_sc_b`](#uint32_t-__builtin_riscv_cv_simd_or_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_xor_h`](#uint32_t-__builtin_riscv_cv_simd_xor_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_xor_b`](#uint32_t-__builtin_riscv_cv_simd_xor_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_xor_sc_h`](#uint32_t-__builtin_riscv_cv_simd_xor_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_xor_sc_b`](#uint32_t-__builtin_riscv_cv_simd_xor_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_and_h`](#uint32_t-__builtin_riscv_cv_simd_and_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_and_b`](#uint32_t-__builtin_riscv_cv_simd_and_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_and_sc_h`](#uint32_t-__builtin_riscv_cv_simd_and_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_and_sc_b`](#uint32_t-__builtin_riscv_cv_simd_and_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_abs_h`](#uint32_t-__builtin_riscv_cv_simd_abs_h-uint32_t-i)
+- [`uint32_t __builtin_riscv_cv_simd_abs_b`](#uint32_t-__builtin_riscv_cv_simd_abs_b-uint32_t-i)
+
+**Note.*** The documentation of these instructions uses `op2`, to refer to `rs2` for vector operations and `rs2` or `Is2` for scalar replication instructions.
 
 **Note.** SIMD registers are always specified as uint32_t, even though the components of the vector may be treated as signed.
 
@@ -869,7 +1000,7 @@ or case b) shft is non-zero
 - result: `rD`
 - i: `rs1`
 - j: `rs2`
-- shft: selector for which SIMD complex-number addition to use.
+- shft: unused as argument, indicates which instruction to select.
 
 _Generated assembler:_
 
@@ -963,7 +1094,7 @@ or case b) shft is non-zero
 - result: `rD`
 - i: `rs1`
 - j: `rs2`
-- shft: selector for which SIMD complex-number subtraction to use.
+- shft: unused as argument, indicates which instruction to select.
 
 _Generated assembler:_
 
@@ -1987,6 +2118,13 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 
 **Applicability.** 32-bit cores.
 
+- [`int32_t __builtin_riscv_cv_simd_extract_h`](#int32_t-__builtin_riscv_cv_simd_extract_h-uint32_t-i-const-uint8_t-sel)
+- [`int32_t __builtin_riscv_cv_simd_extract_b`](#int32_t-__builtin_riscv_cv_simd_extract_b-uint32_t-i-const-uint8_t-sel)
+- [`uint32_t __builtin_riscv_cv_simd_extractu_h`](#uint32_t-__builtin_riscv_cv_simd_extractu_h-uint32_t-i-const-uint8_t-sel)
+- [`uint32_t __builtin_riscv_cv_simd_extractu_b`](#uint32_t-__builtin_riscv_cv_simd_extractu_b-uint32_t-i-const-uint8_t-sel)
+- [`uint32_t __builtin_riscv_cv_simd_insert_h`](#uint32_t-__builtin_riscv_cv_simd_insert_h-uint32_t-i-uint32_t-j-const-uint8_t-sel)
+- [`uint32_t __builtin_riscv_cv_simd_insert_b`](#uint32_t-__builtin_riscv_cv_simd_insert_b-uint32_t-i-uint32_t-j-const-uint8_t-sel)
+
 #### `int32_t __builtin_riscv_cv_simd_extract_h (uint32_t i, const uint8_t sel)`
 
 _Argument/result mapping:_
@@ -2073,9 +2211,36 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 
 ### SIMD dot product operations (32-bit)
 
+**Applicability.** 32-bit cores.
+
+- [`uint32_t __builtin_riscv_cv_simd_dotup_h`](#uint32_t-__builtin_riscv_cv_simd_dotup_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_dotup_b`](#uint32_t-__builtin_riscv_cv_simd_dotup_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_dotup_sc_h`](#uint32_t-__builtin_riscv_cv_simd_dotup_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_dotup_sc_b`](#uint32_t-__builtin_riscv_cv_simd_dotup_sc_b-uint32_t-i-uint8_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotusp_h`](#int32_t-__builtin_riscv_cv_simd_dotusp_h-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotusp_b`](#int32_t-__builtin_riscv_cv_simd_dotusp_b-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotusp_sc_h`](#int32_t-__builtin_riscv_cv_simd_dotusp_sc_h-uint32_t-i-int16_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotusp_sc_b`](#int32_t-__builtin_riscv_cv_simd_dotusp_sc_b-uint32_t-i-int8_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotsp_h`](#int32_t-__builtin_riscv_cv_simd_dotsp_h-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotsp_b`](#int32_t-__builtin_riscv_cv_simd_dotsp_b-uint32_t-i-uint32_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotsp_sc_h`](#int32_t-__builtin_riscv_cv_simd_dotsp_sc_h-uint32_t-i-int16_t-j)
+- [`int32_t __builtin_riscv_cv_simd_dotsp_sc_b`](#int32_t-__builtin_riscv_cv_simd_dotsp_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_sdotup_h`](#uint32_t-__builtin_riscv_cv_simd_sdotup_h-uint32_t-i-uint32_t-j-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_sdotup_b`](#uint32_t-__builtin_riscv_cv_simd_sdotup_b-uint32_t-i-uint32_t-j-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_sdotup_sc_h`](#uint32_t-__builtin_riscv_cv_simd_sdotup_sc_h-uint32_t-i-uint16_t-j-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_sdotup_sc_b`](#uint32_t-__builtin_riscv_cv_simd_sdotup_sc_b-uint32_t-i-uint8_t-j-uint32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotusp_h`](#int32_t-__builtin_riscv_cv_simd_sdotusp_h-uint32_t-i-uint32_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotusp_b`](#int32_t-__builtin_riscv_cv_simd_sdotusp_b-uint32_t-i-uint32_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotusp_sc_h`](#int32_t-__builtin_riscv_cv_simd_sdotusp_sc_h-uint32_t-i-int16_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotusp_sc_b`](#int32_t-__builtin_riscv_cv_simd_sdotusp_sc_b-uint32_t-i-int8_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotsp_h`](#int32_t-__builtin_riscv_cv_simd_sdotsp_h-uint32_t-i-uint32_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotsp_b`](#int32_t-__builtin_riscv_cv_simd_sdotsp_b-uint32_t-i-uint32_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotsp_sc_h`](#int32_t-__builtin_riscv_cv_simd_sdotsp_sc_h-uint32_t-i-int16_t-j-int32_t-k)
+- [`int32_t __builtin_riscv_cv_simd_sdotsp_sc_b`](#int32_t-__builtin_riscv_cv_simd_sdotsp_sc_b-uint32_t-i-int8_t-j-int32_t-k)
+
 **Note.*** The documentation of these instructions uses `op2`, to refer to `rs2` for vector operations and `rs2` or `Is2` for scalar replication instructions.
 
-**Applicability.** 32-bit cores.
+**Note.** SIMD registers are always specified as uint32_t, even though the components of the vector may be treated as signed.
 
 #### `uint32_t __builtin_riscv_cv_simd_dotup_h (uint32_t i, uint32_t j)`
 
@@ -2543,6 +2708,17 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 
 **Applicability.** 32-bit cores.
 
+- [`uint32_t __builtin_riscv_cv_simd_shuffle_h`](#uint32_t-__builtin_riscv_cv_simd_shuffle_h-uint32_t--i-uint32_t-flgs)
+- [`uint32_t __builtin_riscv_cv_simd_shuffle_sci_h`](#uint32_t-__builtin_riscv_cv_simd_shuffle_sci_h-uint32_t-i-const-uint8_t-flgs)
+- [`uint32_t __builtin_riscv_cv_simd_shuffle_b`](#uint32_t-__builtin_riscv_cv_simd_shuffle_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_shuffle_sci_b`](#uint32_t-__builtin_riscv_cv_simd_shuffle_sci_b-uint32_t-i-const-uint8_t-flgs)
+- [`uint32_t __builtin_riscv_cv_simd_shuffle2_h`](#uint32_t-__builtin_riscv_cv_simd_shuffle2_h-uint32_t-i-uint32_t-flgs-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_shuffle2_b`](#uint32_t-__builtin_riscv_cv_simd_shuffle2_b-uint32_t-i-uint32_t-flgs-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_pack`](#uint32_t-__builtin_riscv_cv_simd_pack-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_pack_h`](#uint32_t-__builtin_riscv_cv_simd_pack_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_packhi_b`](#uint32_t-__builtin_riscv_cv_simd_packhi_b-uint32_t-i-uint32_t-j-uint32_t-k)
+- [`uint32_t __builtin_riscv_cv_simd_packlo_b`](#uint32_t-__builtin_riscv_cv_simd_packlo_b-uint32_t-i-uint32_t-j-uint32_t-k)
+
 #### `uint32_t __builtin_riscv_cv_simd_shuffle_h (uint32_t  i, uint32_t flgs)`
 
 _Argument/result mapping:_
@@ -2695,6 +2871,47 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 ### SIMD comparison operations (32-bit)
 
 **Applicability.** 32-bit cores.
+
+- [`uint32_t __builtin_riscv_cv_simd_cmpeq_h`](#uint32_t-__builtin_riscv_cv_simd_cmpeq_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpeq_b`](#uint32_t-__builtin_riscv_cv_simd_cmpeq_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpeq_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpeq_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpeq_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpeq_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpne_h`](#uint32_t-__builtin_riscv_cv_simd_cmpne_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpne_b`](#uint32_t-__builtin_riscv_cv_simd_cmpne_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpne_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpne_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpne_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpne_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgt_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgt_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgt_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgt_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgt_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgt_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgt_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgt_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpge_h`](#uint32_t-__builtin_riscv_cv_simd_cmpge_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpge_b`](#uint32_t-__builtin_riscv_cv_simd_cmpge_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpge_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpge_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpge_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpge_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmplt_h`](#uint32_t-__builtin_riscv_cv_simd_cmplt_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmplt_b`](#uint32_t-__builtin_riscv_cv_simd_cmplt_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmplt_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmplt_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmplt_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmplt_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmple_h`](#uint32_t-__builtin_riscv_cv_simd_cmple_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmple_b`](#uint32_t-__builtin_riscv_cv_simd_cmple_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmple_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmple_sc_h-uint32_t-i-int16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmple_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmple_sc_b-uint32_t-i-int8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgtu_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgtu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgtu_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgtu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgtu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgtu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgtu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgtu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgeu_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgeu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgeu_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgeu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgeu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpgeu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpgeu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpgeu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpltu_h`](#uint32_t-__builtin_riscv_cv_simd_cmpltu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpltu_b`](#uint32_t-__builtin_riscv_cv_simd_cmpltu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpltu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpltu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpltu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpltu_sc_b-uint32_t-i-uint8_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpleu_h`](#uint32_t-__builtin_riscv_cv_simd_cmpleu_h-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpleu_b`](#uint32_t-__builtin_riscv_cv_simd_cmpleu_b-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpleu_sc_h`](#uint32_t-__builtin_riscv_cv_simd_cmpleu_sc_h-uint32_t-i-uint16_t-j)
+- [`uint32_t __builtin_riscv_cv_simd_cmpleu_sc_b`](#uint32_t-__builtin_riscv_cv_simd_cmpleu_sc_b-uint32_t-i-uint8_t-j)
 
 #### `uint32_t __builtin_riscv_cv_simd_cmpeq_h (uint32_t i, uint32_t j)`
 
@@ -3466,46 +3683,51 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 
 **Applicability.** 32-bit cores.
 
+- [`uint32_t __builtin_riscv_cv_simd_cplxmul_r`](#uint32_t-__builtin_riscv_cv_simd_cplxmul_r-uint32_t-i-uint32_t-j-uint32_t-k-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_simd_cplxmul_i`](#uint32_t-__builtin_riscv_cv_simd_cplxmul_i-uint32_t-i-uint32_t-j-uint32_t-k-const-uint8_t-shft)
+- [`uint32_t __builtin_riscv_cv_simd_cplxconj`](#uint32_t-__builtin_riscv_cv_simd_cplxconj-uint32_t-i)
+- [`uint32_t __builtin_riscv_cv_simd_subrotmj`](#uint32_t-__builtin_riscv_cv_simd_subrotmj-uint32_t--i-uint32_t-j-const-uint8_t-shft)
+
 **Note.** The complex addition and subtraction operations are specialized versions of the SIMD half word addition and subraction described in [SIMD ALU operations (32-bit)](#simd-alu-operations-32-bit) above.
 
 #### `uint32_t __builtin_riscv_cv_simd_cplxmul_r (uint32_t i, uint32_t j, uint32_t k, const uint8_t shft)`
 
-This instruction comes in variants which shift by 15, 16, 17 or 18, in order to divide the lower half word of `rD` by 1, 2, 4 or 8.
+This instruction comes in variants which shift by 15, 16, 17 or 18, in order to divide the lower half word of `rD` by 1, 2, 4 or 8.  For consistency with `_builtin_riscv_cv_simd_add_h` and `__builtin_riscv_cv_simd_subrotmj`, the shift argument takes the values 0 through 3 to indicate which division is needed.
 
 _Argument/result mapping:_
 
 - result, k: `rD`
 - i: `rs1`
 - j: `rs2`
-- shft: unused
+- shft: unused as argument, indicates which instruction to select.
 
 _Generated assembler:_
 
 ```gas
-        cv.cplxmul.r       rD,rs1,rs2   ;; shft = 15
-        cv.cplxmul.r.div2  rD,rs1,rs2   ;; shft = 16
-        cv.cplxmul.r.div4  rD,rs1,rs2   ;; shft = 17
-        cv.cplxmul.r.div8  rD,rs1,rs2   ;; shft = 18
+        cv.cplxmul.r       rD,rs1,rs2   ;; shft = 0
+        cv.cplxmul.r.div2  rD,rs1,rs2   ;; shft = 1
+        cv.cplxmul.r.div4  rD,rs1,rs2   ;; shft = 2
+        cv.cplxmul.r.div8  rD,rs1,rs2   ;; shft = 3
 ```
 
 #### `uint32_t __builtin_riscv_cv_simd_cplxmul_i (uint32_t i, uint32_t j, uint32_t k, const uint8_t shft)`
 
-This instruction comes in variants which shift by 15, 16, 17 or 18, in order to divide the upper half word of `rD` by 1, 2, 4 or 8.
+This instruction comes in variants which shift by 15, 16, 17 or 18, in order to divide the upper half word of `rD` by 1, 2, 4 or 8.  For consistency with `_builtin_riscv_cv_simd_add_h` and `__builtin_riscv_cv_simd_subrotmj`, the shift argument takes the values 0 through 3 to indicate which division is needed.
 
 _Argument/result mapping:_
 
 - result, k: `rD`
 - i: `rs1`
 - j: `rs2`
-- shft: unused
+- shft: unused as argument, indicates which instruction to select.
 
 _Generated assembler:_
 
 ```gas
-        cv.cplxmul.i       rD,rs1,rs2   ;; shft = 15
-        cv.cplxmul.i.div2  rD,rs1,rs2   ;; shft = 16
-        cv.cplxmul.i.div4  rD,rs1,rs2   ;; shft = 17
-        cv.cplxmul.i.div8  rD,rs1,rs2   ;; shft = 18
+        cv.cplxmul.i       rD,rs1,rs2   ;; shft = 0
+        cv.cplxmul.i.div2  rD,rs1,rs2   ;; shft = 1
+        cv.cplxmul.i.div4  rD,rs1,rs2   ;; shft = 2
+        cv.cplxmul.i.div8  rD,rs1,rs2   ;; shft = 3
 ```
 
 #### `uint32_t __builtin_riscv_cv_simd_cplxconj (uint32_t i)`
@@ -3530,7 +3752,7 @@ _Argument/result mapping:_
 - result: `rD`
 - i: `rs1`
 - j: `rs2`
-- shft: unused
+- shft: unused as argument, indicates which instruction to select.
 
 _Generated assembler:_
 
@@ -3549,9 +3771,23 @@ At the time of writing the SIMD architecture for 64-bit is not defined, so no bu
 
 ## Listing of PULP bit manipulation builtins (`xcvbitmanip`)
 
-### PULP bit manipulation builtins for 32-bit cores
+### PULP bit manipulation builtins (32-bit)
 
-Some of these functions modify the destination register, so need the value passed by reference, although for convenience the modfied value is returned as result.
+**Applicability.** 32-bit cores.
+
+- [`int32_t __builtin_riscv_cv_bitmanip_extract`](#int32_t-__builtin_riscv_cv_bitmanip_extract-uint32_t--i-uint16_t-range)
+- [`uint32_t __builtin_riscv_cv_bitmanip_extractu`](#uint32_t-__builtin_riscv_cv_bitmanip_extractu-uint32_t-i-uint16_t-range)
+- [`uint32_t __builtin_riscv_cv_bitmanip_insert(uint32_t i, uint16_t range, uint32_t  k)`](#uint32_t-__builtin_riscv_cv_bitmanip_insertuint32_t-i-uint16_t-range-uint32_t--k)
+- [`uint32_t __builtin_riscv_cv_bitmanip_bclr`](#uint32_t-__builtin_riscv_cv_bitmanip_bclr-uint32_t-i-uint16_t-range)
+- [`uint32_t __builtin_riscv_cv_bitmanip_bset`](#uint32_t-__builtin_riscv_cv_bitmanip_bset-uint32_t-i-uint16_t-range)
+- [`uint8_t __builtin_riscv_cv_bitmanip_ff1`](#uint8_t-__builtin_riscv_cv_bitmanip_ff1-uint32_t-i)
+- [`uint8_t __builtin_riscv_cv_bitmanip_fl1`](#uint8_t-__builtin_riscv_cv_bitmanip_fl1-uint32_t-i)
+- [`uint8_t __builtin_riscv_cv_bitmanip_clb`](#uint8_t-__builtin_riscv_cv_bitmanip_clb-uint32_t-i)
+- [`uint8_t __builtin_riscv_cv_bitmanip_cnt`](#uint8_t-__builtin_riscv_cv_bitmanip_cnt-uint32_t-i)
+- [`uint32_t __builtin_riscv_cv_bitmanip_ror`](#uint32_t-__builtin_riscv_cv_bitmanip_ror-uint32_t-i-uint32_t-j)
+- [`uint32_t __builtin_riscv_cv_bitmanip_bitrev`](#uint32_t-__builtin_riscv_cv_bitmanip_bitrev-uint32_t-i-uint8_t-pts-uint8_t-radix)
+
+**Note:** Some of these functions modify the destination register, so need the value passed by reference, although for convenience the modfied value is returned as result.
 
 #### `int32_t __builtin_riscv_cv_bitmanip_extract (uint32_t  i, uint16_t range)`
 
@@ -3577,7 +3813,7 @@ or case b)
         cv.extractr  rD,rs1,rs2
 ```
 
-#### `uint32_t __builtin_riscv_cv_bitmanip_extractu (uint32_t, uint8_t, uint8_t)`
+#### `uint32_t __builtin_riscv_cv_bitmanip_extractu (uint32_t i, uint16_t range)`
 
 Case a) range is a constant
 - result: `rD`
@@ -3603,7 +3839,7 @@ or case b)
 
 #### `uint32_t __builtin_riscv_cv_bitmanip_insert(uint32_t i, uint16_t range, uint32_t  k)`
 
-Case a) range is a constant and `(range[9:5] + range [4:0]) <= 32` (TBC)
+Case a) range is a constant and `(range[9:5] + range [4:0]) <= 32`
 - result, k: `rD`
 - i: `rs1`
 - range[4:0]: `Is2` (5-bit unsigned value)
@@ -3734,7 +3970,7 @@ _Generated assembler:_
 - result: `rD`
 - i: `rs1`
 - pts: `Is2` (5-bit unsigned integer)
-- radix: `Is3[0:1] (2-bit unsigned integer)
+- radix: `Is3[1:0] (2-bit unsigned integer)
 
 _Generated assembler: (TBC)_
 
@@ -3742,7 +3978,7 @@ _Generated assembler: (TBC)_
         cv.bitrev  rD,rs1,Is2,Is3
 ```
 
-### PULP bit manipulation builtins for 64-bit cores
+### PULP bit manipulation builtins (64-bit)
 
 **Applicability.** 64-bit cores.
 
@@ -3750,12 +3986,16 @@ At the time of writing the bit manipulation architecture for 64-bit is not defin
 
 ## Listing of event load word builtins (`xcvelw`)
 
-### Event load word builtins for 32-bit cores
+### Event load word builtins (32-bit)
+
+**Applicability.** 32-bit cores.
+
+- [`uint32_t __builtin_riscv_cv_elw_elw`](#uint32_t-__builtin_riscv_cv_elw_elw-uint32_t-*loc)
 
 #### `uint32_t __builtin_riscv_cv_elw_elw (uint32_t *loc)`
 
 - result: `rD`
-- loc: `Imm(rs1)` (`Imm` and `rs1` determined by the compiler.
+- loc: `Imm(rs1)` (`Imm` and `rs1` determined by the compiler).
 
 _Generated assembler:_
 
@@ -3763,7 +4003,7 @@ _Generated assembler:_
         cv.elw  rD,Imm(rs1)
 ```
 
-### Event load word builtins for 64-bit core
+### Event load word builtins (64-bit)
 
 **Applicability.** 64-bit cores.
 


### PR DESCRIPTION
	* specifications/corev-builtin-spec.md: Corrections from Pascal Gouedo, add quick links table at start of each section.